### PR TITLE
fix: patch 1.5.2

### DIFF
--- a/package/Tact.tmLanguage
+++ b/package/Tact.tmLanguage
@@ -243,8 +243,18 @@
                 <string>keyword.operator.mapsto.tact</string>
               </dict>
               <dict>
+                <key>comment</key>
+                <string>Decimal integer WITH leading zero</string>
                 <key>match</key>
-                <string>\b([0-9]+)\b</string>
+                <string>\b(0[0-9]*)\b</string>
+                <key>name</key>
+                <string>constant.numeric.decimal.tact</string>
+              </dict>
+              <dict>
+                <key>comment</key>
+                <string>Decimal integer WITHOUT leading zero</string>
+                <key>match</key>
+                <string>\b([1-9](?:_?[0-9])*)\b</string>
                 <key>name</key>
                 <string>constant.numeric.decimal.tact</string>
               </dict>

--- a/package/Tact.tmLanguage.json
+++ b/package/Tact.tmLanguage.json
@@ -158,7 +158,13 @@
               "name": "keyword.operator.mapsto.tact"
             },
             {
-              "match": "\\b([0-9]+)\\b",
+              "comment": "Decimal integer WITH leading zero",
+              "match": "\\b(0[0-9]*)\\b",
+              "name": "constant.numeric.decimal.tact"
+            },
+            {
+              "comment": "Decimal integer WITHOUT leading zero",
+              "match": "\\b([1-9](?:_?[0-9])*)\\b",
               "name": "constant.numeric.decimal.tact"
             }
           ],

--- a/tests/syntax_test_asm_function.tact
+++ b/tests/syntax_test_asm_function.tact
@@ -1,0 +1,86 @@
+// SYNTAX TEST "Packages/Tact/package/Tact.tmLanguage"
+
+asm fun empty() { }
+// <- entity.other.attribute-name.tact
+//  ^^^ keyword.other.function.tact
+//      ^^^^^ entity.name.function.tact
+//           ^ punctuation.brackets.round.tact
+//            ^ punctuation.brackets.round.tact
+//              ^ punctuation.brackets.curly.tact
+//                ^ punctuation.brackets.curly.tact
+
+asm() fun empty2() { }
+// <- entity.other.attribute-name.tact
+// ^^ punctuation.brackets.round.tact
+
+asm(-> 000) fun rets(): Int { }
+// <- entity.other.attribute-name.tact
+// ^ punctuation.brackets.round.tact
+//  ^^ keyword.operator.mapsto.tact
+//     ^^^ constant.numeric.decimal.tact
+//        ^ punctuation.brackets.round.tact
+
+asm(arg1 arg2 -> 0) fun args(arg1: Int, arg2: Int): Int { }
+// <- entity.other.attribute-name.tact
+// ^ punctuation.brackets.round.tact
+//  ^^^^ variable.other.tact
+//       ^^^^ variable.other.tact
+//            ^^ keyword.operator.mapsto.tact
+//               ^ constant.numeric.decimal.tact
+//                ^ punctuation.brackets.round.tact
+
+struct Eleven { /* imagine 11 fields */ }
+
+asm(-> 1_0 9 8 7 6 5 4 3 2 1 0) extends fun eleven(self: Int): Eleven { INSTRUCTION INSTRUCTION 000 }
+// <- entity.other.attribute-name.tact
+// ^ punctuation.brackets.round.tact
+//  ^^ keyword.operator.mapsto.tact
+//     ^^^ constant.numeric.decimal.tact
+//         ^ constant.numeric.decimal.tact
+//           ^ constant.numeric.decimal.tact
+//             ^ constant.numeric.decimal.tact
+//               ^ constant.numeric.decimal.tact
+//                 ^ constant.numeric.decimal.tact
+//                   ^ constant.numeric.decimal.tact
+//                     ^ constant.numeric.decimal.tact
+//                       ^ constant.numeric.decimal.tact
+//                         ^ constant.numeric.decimal.tact
+//                           ^ constant.numeric.decimal.tact
+//                            ^ punctuation.brackets.round.tact
+//                              ^^^^^^^ keyword.other.attribute.tact
+//                                      ^^^ keyword.other.function.tact
+//                                          ^^^^^^ entity.name.function.tact
+//                                                ^ punctuation.brackets.round.tact
+//                                                 ^^^^ variable.language.this.tact
+//                                                     ^ punctuation.colon.tact
+//                                                       ^^^ entity.name.type.tact
+//                                                          ^ punctuation.brackets.round.tact
+//                                                           ^ punctuation.colon.tact
+//                                                             ^^^^^^ entity.name.type.tact
+//                                                                    ^ punctuation.brackets.curly.tact
+//                                                                      ^^^^^^^^^^^ constant.other.caps.tact
+//                                                                                  ^^^^^^^^^^^ constant.other.caps.tact
+//                                                                                              ^^^ constant.numeric.decimal.tact
+//                                                                                                  ^ punctuation.brackets.curly.tact
+
+asm fun isIntAnInt(x: Int): Bool {
+    <{
+        TRY:<{
+            0 PUSHINT ADD DROP -1 PUSHINT
+            // <- constant.numeric.decimal.tact
+            //^^^^^^^ constant.other.caps.tact
+            //        ^^^ constant.other.caps.tact
+            //            ^^^^ constant.other.caps.tact
+            //                 ^ keyword.operator.arithmetic.tact
+            //                  ^ constant.numeric.decimal.tact
+            //                    ^^^^^^^ constant.other.caps.tact
+        }>CATCH<{
+            2DROP 0 PUSHINT
+            //    ^ constant.numeric.decimal.tact
+            //      ^^^^^^^ constant.other.caps.tact
+        }>
+    }>CONT 1 1 CALLXARGS
+    //     ^ constant.numeric.decimal.tact
+    //       ^ constant.numeric.decimal.tact
+    //         ^^^^^^^^^ constant.other.caps.tact
+}


### PR DESCRIPTION
Corrects highlighting of return indexes in asm arrangements/shuffles according to `grammar.ohm` of Tact