### PR TITLE
fix: patch 1.5.3

### DIFF
--- a/package/Tact.sublime-completions
+++ b/package/Tact.sublime-completions
@@ -17,7 +17,8 @@
         {
             "trigger": "asm\tasm with optional arrangement (...)",
             "contents": "asm $0",
-            "kind": ["function", "a", "Attribute"]
+            "kind": ["function", "a", "Attribute"],
+            "details": "<a href=\"https://docs.tact-lang.org/book/assembly-functions\">Tact Docs</a>"
         },
 
         // Literals, Base trait and constants
@@ -108,7 +109,8 @@
         {
             "trigger": "SendOnlyEstimateFee\tequal to 1024",
             "contents": "SendOnlyEstimateFee",
-            "kind": ["variable", "c", "Constant"]
+            "kind": ["variable", "c", "Constant"],
+            "details": "<a href=\"https://docs.tact-lang.org/book/message-mode#base-modes\">Tact Docs</a>"
         },
         {
             "trigger": "ReserveExact\tequal to 0",
@@ -163,12 +165,14 @@
         {
             "trigger": "StdAddress",
             "contents": "StdAddress",
-            "kind": ["variable", "s", "Struct"]
+            "kind": ["variable", "s", "Struct"],
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#parsestdaddress\">Tact Docs</a>"
         },
         {
             "trigger": "VarAddress",
             "contents": "VarAddress",
-            "kind": ["variable", "s", "Struct"]
+            "kind": ["variable", "s", "Struct"],
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#parsevaraddress\">Tact Docs</a>"
         },
 
         // Built-in types and serialization options
@@ -630,22 +634,26 @@
         {
             "trigger": "slice\tSlice from a BoC String at compile-time",
             "contents": "slice(${1:bocBase64String})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-comptime#slice\">Tact Docs</a>"
         },
         {
             "trigger": "rawSlice\tSlice from a String at compile-time",
             "contents": "rawSlice(${1:someString})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-comptime#rawslice\">Tact Docs</a>"
         },
         {
-            "trigger": "ascii\tInt sum of ASCII values at compile-time",
+            "trigger": "ascii\tInt of hex of ASCII characters at compile-time",
             "contents": "aslii(${1:asciiString})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-comptime#ascii\">Tact Docs</a>"
         },
         {
             "trigger": "crc32\tCRC32 of a String at compile-time",
             "contents": "crc32(${1:someString})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-comptime#crc32\">Tact Docs</a>"
         },
 
         // Core library: Debug
@@ -694,12 +702,14 @@
         {
             "trigger": "parseStdAddress\tparse StdAddress from a Slice",
             "contents": "parseStdAddress(${1:slice_Slice})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#parsestdaddress\">Tact Docs</a>"
         },
         {
             "trigger": "parseVarAddress\tparse VarAddress from a Slice",
             "contents": "parseVarAddress(${1:slice_Slice})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#parsevaraddress\">Tact Docs</a>"
         },
 
         // Core library: Random
@@ -868,15 +878,16 @@
             "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced#nativerandominterval\">Tact Docs</a>"
         },
         {
-            "trigger": "nativeSendMessage\tsend message Cell with mode Int",
-            "contents": "nativeSendMessage(${1:cell}, ${2:mode_Int})",
+            "trigger": "nativeSendMessage\tsend msg Cell with mode Int",
+            "contents": "nativeSendMessage(${1:msg_Cell}, ${2:mode_Int})",
             "kind": "function",
             "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced#nativesendmessage\">Tact Docs</a>"
         },
         {
-            "trigger": "nativeSendMessageReturnForwardFee\tsend message Cell with mode Int and get fees",
-            "contents": "nativeSendMessageReturnForwardFee(${1:cell}, ${2:mode_Int})",
-            "kind": "function"
+            "trigger": "nativeSendMessageReturnForwardFee\tsend msg Cell with mode Int and get fees",
+            "contents": "nativeSendMessageReturnForwardFee(${1:msg_Cell}, ${2:mode_Int})",
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced#nativesendmessagereturnforwardfee\">Tact Docs</a>"
         },
         {
             "trigger": "nativeReserve\treserve nanoToncoin amount Int with mode Int",
@@ -885,49 +896,52 @@
             "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced#nativereserve\">Tact Docs</a>"
         },
         {
-            "trigger": "nativeReserve\treserve nanoToncoin amount Int with mode Int",
-            "contents": "nativeReserve(${1:amount_Int}, ${2:mode_Int})",
-            "kind": "function"
-        },
-        {
             "trigger": "gasConsumed\tget gas consumed so far",
             "contents": "gasConsumed()",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#gasconsumed\">Tact Docs</a>"
         },
         {
             "trigger": "getComputeFee\tcalc compute cost in nanoToncoins",
             "contents": "getComputeFee(${1:gas_used_Int, ${2:is_masterchain_Bool})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#getcomputefee\">Tact Docs</a>"
         },
         {
             "trigger": "getStorageFee\tcalc storage fees in nanoToncoins",
             "contents": "getStorageFee(${1:cells_Int, ${2:bits_Int}, ${3:seconds_Int}, ${4:is_masterchain_Bool})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#getstoragefee\">Tact Docs</a>"
         },
         {
             "trigger": "getForwardFee\tcalc forward fees in nanoToncoins",
             "contents": "getForwardFee(${1:cells_Int, ${2:bits_Int}, ${3:is_masterchain_Bool})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#getforwardfee\">Tact Docs</a>"
         },
         {
             "trigger": "getSimpleComputeFee\tcalc extra compute cost in nanoToncoins",
             "contents": "getSimpleComputeFee(${1:gas_used_Int, ${2:is_masterchain_Bool})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#getsimplecomputefee\">Tact Docs</a>"
         },
         {
             "trigger": "getSimpleForwardFee\tcalc extra forward fees in nanoToncoins",
             "contents": "getSimpleForwardFee(${1:cells_Int, ${2:bits_Int}, ${3:is_masterchain_Bool})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#getsimpleforwardfee\">Tact Docs</a>"
         },
         {
             "trigger": "getOriginalFwdFee\tcalc original fwd_fee in nanoToncoins",
             "contents": "getOriginalFwdFee(${1:fwd_fee_Int, ${2:is_masterchain_Bool})",
-            "kind": "function"
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#getoriginalfwdfee\">Tact Docs</a>"
         },
         {
             "trigger": "myStorageDue\tstorage fee debt in nanoToncoins",
-            "contents": "myStorageDue(${1:fwd_fee_Int, ${2:is_masterchain_Bool})",
-            "kind": "function"
+            "contents": "myStorageDue()",
+            "kind": "function",
+            "details": "<a href=\"https://docs.tact-lang.org/ref/core-advanced/#mystoragedue\">Tact Docs</a>"
         },
     ]
 }

--- a/package/Tact.tmLanguage
+++ b/package/Tact.tmLanguage
@@ -216,7 +216,7 @@
               <key>1</key>
               <dict>
                 <key>name</key>
-                <string>entity.other.attribute-name.tact</string>
+                <string>keyword.other.asm.tact</string>
               </dict>
               <key>2</key>
               <dict>
@@ -268,9 +268,17 @@
             <key>comment</key>
             <string>Fallback match</string>
             <key>match</key>
-            <string>(?&lt;!\.)\b(@name|@interface|asm)\b</string>
+            <string>(?&lt;!\.)\b(@name|@interface)\b</string>
             <key>name</key>
             <string>entity.other.attribute-name.tact</string>
+          </dict>
+          <dict>
+            <key>comment</key>
+            <string>Fallback match</string>
+            <key>match</key>
+            <string>(?&lt;!\.)\b(asm)\b</string>
+            <key>name</key>
+            <string>keyword.other.asm.tact</string>
           </dict>
         </array>
       </dict>

--- a/package/Tact.tmLanguage
+++ b/package/Tact.tmLanguage
@@ -4,18 +4,12 @@
   <dict>
     <key>name</key>
     <string>Tact</string>
-    <key>displayName</key>
-    <string>Tact</string>
     <key>scopeName</key>
     <string>source.tact</string>
     <key>fileTypes</key>
     <array>
       <string>tact</string>
     </array>
-    <key>foldingStartMarker</key>
-    <string>\{\s*$</string>
-    <key>foldingStopMarker</key>
-    <string>^\s*\}</string>
     <key>patterns</key>
     <array>
       <dict>
@@ -128,7 +122,7 @@
       <key>todo</key>
       <dict>
         <key>match</key>
-        <string>(?i)\b(FIXME|TODO|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG)\b(?-i)</string>
+        <string>\b(FIXME|TODO|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG)\b</string>
         <key>name</key>
         <string>keyword.comment.todo.tact</string>
       </dict>
@@ -617,7 +611,7 @@
         <array>
           <dict>
             <key>match</key>
-            <string>(?&lt;!\.)\b(as)\s+(coins|remaining|bytes32|bytes64|int257|u?int(?:2[0-5][0-6]|1[0-9][0-9]|[1-9][0-9]?))\b</string>
+            <string>(?&lt;!\.)\b(as)\s+(coins|remaining|bytes(?:32|64)|int257|u?int(?:25[0-6]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]?))\b</string>
             <key>captures</key>
             <dict>
               <key>1</key>

--- a/package/Tact.tmLanguage.json
+++ b/package/Tact.tmLanguage.json
@@ -1,12 +1,9 @@
 {
   "name": "Tact",
-  "displayName": "Tact",
   "scopeName": "source.tact",
   "fileTypes": [
     "tact"
   ],
-  "foldingStartMarker": "\\{\\s*$",
-  "foldingStopMarker": "^\\s*\\}",
   "patterns": [
     {
       "include": "#comment"
@@ -84,7 +81,7 @@
     },
 
     "todo": {
-      "match": "(?i)\\b(FIXME|TODO|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG)\\b(?-i)",
+      "match": "\\b(FIXME|TODO|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG)\\b",
       "name": "keyword.comment.todo.tact"
     },
 
@@ -402,7 +399,7 @@
         "comment": "Serialization",
         "patterns": [
           {
-            "match": "(?<!\\.)\\b(as)\\s+(coins|remaining|bytes32|bytes64|int257|u?int(?:2[0-5][0-6]|1[0-9][0-9]|[1-9][0-9]?))\\b",
+            "match": "(?<!\\.)\\b(as)\\s+(coins|remaining|bytes(?:32|64)|int257|u?int(?:25[0-6]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]?))\\b",
             "captures": {
               "1": {
                 "name": "keyword.other.as.tact storage.modifier.tact"

--- a/package/Tact.tmLanguage.json
+++ b/package/Tact.tmLanguage.json
@@ -140,7 +140,7 @@
           "begin": "(?<!\\.)(asm)\\s*(\\()",
           "beginCaptures": {
             "1": {
-              "name": "entity.other.attribute-name.tact"
+              "name": "keyword.other.asm.tact"
             },
             "2": {
               "name": "punctuation.brackets.round.tact"
@@ -174,8 +174,13 @@
         },
         {
           "comment": "Fallback match",
-          "match": "(?<!\\.)\\b(@name|@interface|asm)\\b",
+          "match": "(?<!\\.)\\b(@name|@interface)\\b",
           "name": "entity.other.attribute-name.tact"
+        },
+        {
+          "comment": "Fallback match",
+          "match": "(?<!\\.)\\b(asm)\\b",
+          "name": "keyword.other.asm.tact"
         }
       ]
     },

--- a/tests/syntax_test_import.tact
+++ b/tests/syntax_test_import.tact
@@ -7,7 +7,7 @@ import "@stdlib/deploy";
 //                    ^ string.quoted.double.tact punctuation.definition.string.end.tact
 //                     ^ punctuation.semi.tact
 
-// comment
+// NOTE: comment
 // <- comment.line.double-slash.tact punctuation.definition.comment.line.double-slash.tact
 
 /* multi-line comment/doc-string */

--- a/tests/syntax_test_struct.tact
+++ b/tests/syntax_test_struct.tact
@@ -79,7 +79,7 @@ struct Serialization {
     //         ^^^^^^ entity.name.type.tact
     f7: Int as uint200;
     //         ^^^^^^^ entity.name.type.tact
-    f8: Int as int200;
+    f8: Int as int249;
     //         ^^^^^^ entity.name.type.tact
     f9: Int as uint256;
     //         ^^^^^^^ entity.name.type.tact


### PR DESCRIPTION
* fix: patch highlighting of serialization formats and remove of invalid properties
* feat: highlight `asm` as a keyword
* chore: update links to documentation pages for entities introduced in 1.4.0 and 1.5.0 Tact versions